### PR TITLE
labb-python to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: gog
   repository: http://jenkins-x-chartmuseum:8080
   version: 3.0.45
+- name: labb-python
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.6


### PR DESCRIPTION
Promote labb-python to version 0.0.6